### PR TITLE
Handle study record metadata and index updates

### DIFF
--- a/pages/MarkdownPage.tsx
+++ b/pages/MarkdownPage.tsx
@@ -13,10 +13,117 @@ const studyRecordMarkdowns = import.meta.glob('./study-record/*.md', {
   eager: true,
 }) as Record<string, string>;
 
+interface MarkdownEntry {
+  slug: string;
+  content: string;
+  metadata: Record<string, string>;
+}
+
+interface ParsedMarkdown {
+  content: string;
+  metadata: Record<string, string>;
+}
+
+const parseMarkdown = (raw: string): ParsedMarkdown => {
+  const normalized = raw.replace(/\r\n?/g, '\n');
+  const lines = normalized.split('\n');
+  const metadata: Record<string, string> = {};
+
+  let metaStart = -1;
+  let metaEnd = -1;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+
+    if (match) {
+      if (metaStart === -1) {
+        // allow metadata block only if it appears after optional headings/blank lines
+        let prevIndex = i - 1;
+        while (prevIndex >= 0 && lines[prevIndex].trim() === '') {
+          prevIndex -= 1;
+        }
+        if (prevIndex >= 0 && !lines[prevIndex].trim().startsWith('#')) {
+          break;
+        }
+        metaStart = i;
+      }
+
+      metadata[match[1].trim()] = match[2].trim();
+      continue;
+    }
+
+    if (metaStart !== -1) {
+      metaEnd = i;
+      break;
+    }
+
+    if (line.trim() !== '') {
+      break;
+    }
+  }
+
+  if (metaStart === -1) {
+    return { content: normalized, metadata };
+  }
+
+  if (metaEnd === -1) {
+    metaEnd = lines.length;
+  }
+
+  const contentLines = lines.slice(0, metaStart).concat(lines.slice(metaEnd));
+  const content = contentLines.join('\n').replace(/^\s+/, '');
+
+  return {
+    content,
+    metadata,
+  };
+};
+
+const buildMarkdownIndex = (
+  markdownMap: Record<string, string>,
+  basePath: string,
+): Map<string, MarkdownEntry> => {
+  const index = new Map<string, MarkdownEntry>();
+
+  Object.entries(markdownMap).forEach(([key, rawContent]) => {
+    const relativePath = key.replace(basePath, '').replace(/^\.\//, '');
+    const fileSlug = relativePath.replace(/\.md$/i, '');
+    const { content, metadata } = parseMarkdown(rawContent);
+    const primarySlug = metadata.slug?.trim() || fileSlug;
+
+    const entry: MarkdownEntry = {
+      slug: primarySlug,
+      content,
+      metadata: {
+        ...metadata,
+        slug: primarySlug,
+      },
+    };
+
+    const decodedPrimary = decodeURIComponent(primarySlug);
+    const decodedFileSlug = decodeURIComponent(fileSlug);
+
+    if (!index.has(decodedPrimary)) {
+      index.set(decodedPrimary, entry);
+    }
+
+    if (!index.has(decodedFileSlug)) {
+      index.set(decodedFileSlug, entry);
+    }
+  });
+
+  return index;
+};
+
+const generalMarkdownIndex = buildMarkdownIndex(generalMarkdowns, './');
+const studyRecordMarkdownIndex = buildMarkdownIndex(studyRecordMarkdowns, './study-record/');
+
 const MarkdownPage: React.FC = () => {
   const { slug } = useParams<{ slug: string }>();
   const location = useLocation();
   const [content, setContent] = useState<string>('');
+  const [metadata, setMetadata] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -30,21 +137,19 @@ const MarkdownPage: React.FC = () => {
 
     const decodedSlug = decodeURIComponent(slug);
     const isStudyRecord = location.pathname.startsWith('/study-record/');
-    const markdownMap = isStudyRecord ? studyRecordMarkdowns : generalMarkdowns;
-    const filePath = isStudyRecord
-      ? `./study-record/${decodedSlug}.md`
-      : `./${decodedSlug}.md`;
+    const markdownMap = isStudyRecord ? studyRecordMarkdownIndex : generalMarkdownIndex;
+    const entry = markdownMap.get(decodedSlug);
 
-    const markdownContent = markdownMap[filePath];
-
-    if (!markdownContent) {
+    if (!entry) {
       setError(`'${decodedSlug}' 페이지를 찾을 수 없습니다.`);
       setContent('');
+      setMetadata({});
       setLoading(false);
       return;
     }
 
-    setContent(markdownContent);
+    setContent(entry.content);
+    setMetadata(entry.metadata);
     setLoading(false);
   }, [slug, location.pathname]);
 
@@ -56,7 +161,34 @@ const MarkdownPage: React.FC = () => {
     return <div className="text-center py-10 text-red-600">오류: {error}</div>;
   }
 
-  return <MarkdownRenderer content={content} />;
+  const metaItems = [
+    metadata.date && { label: '작성일', value: metadata.date },
+    metadata.updatedAt && { label: '업데이트', value: metadata.updatedAt },
+    metadata.author && { label: '작성자', value: metadata.author },
+    metadata.tags && { label: '태그', value: metadata.tags },
+    metadata.category && { label: '카테고리', value: metadata.category },
+    metadata.status && { label: '상태', value: metadata.status },
+  ].filter(Boolean) as Array<{ label: string; value: string }>;
+
+  return (
+    <div className="space-y-6">
+      {metaItems.length > 0 && (
+        <section className="rounded-lg border border-neutral-200 bg-neutral-50 px-4 py-3 text-sm text-neutral-700">
+          <dl className="grid gap-3 sm:grid-cols-2">
+            {metaItems.map((item) => (
+              <div key={`${item.label}-${item.value}`} className="flex flex-col gap-0.5">
+                <dt className="font-semibold uppercase tracking-wide text-neutral-500 text-xs">
+                  {item.label}
+                </dt>
+                <dd className="text-neutral-800">{item.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+      )}
+      <MarkdownRenderer content={content} />
+    </div>
+  );
 };
 
 export default MarkdownPage;

--- a/pages/study-record/ASE2010 Applied linear algebra Homework 1 b697e2c3190b4883b44ae37828e4241d.md
+++ b/pages/study-record/ASE2010 Applied linear algebra Homework 1 b697e2c3190b4883b44ae37828e4241d.md
@@ -1,5 +1,6 @@
 # ASE2010 Applied linear algebra: Homework #1
 
+slug: ase2010_hw1
 updatedAt: 2024년 8월 7일 오후 8:58
 
 ## 1) Linear functions

--- a/pages/study-record/index.json
+++ b/pages/study-record/index.json
@@ -53,5 +53,75 @@
     "slug": "고속공기역학 8장 극초음속 유동 2fd35010e3114f0f9a805184bd79ede6",
     "title": "고속공기역학 8장 — 극초음속 유동",
     "summary": "극초음속 영역의 특성, 경계층/충격파 상호작용 개요."
+  },
+  {
+    "slug": "sr-AC001",
+    "title": "자동제어 1. 동역학 복습",
+    "summary": "인하대학교 자동제어 강의에서 다룬 질량-스프링-댐퍼 동역학을 복습하고 핵심 개념을 정리했습니다."
+  },
+  {
+    "slug": "sr-AC002",
+    "title": "자동제어 2. 라플라스 변환",
+    "summary": "용수철-댐퍼 시스템을 라플라스 변환으로 해석하며 전달함수 도출 과정을 단계별로 정리했습니다."
+  },
+  {
+    "slug": "자동제어 3 라플라스 변환과 final value theorem e664631b31e646baad831b85c5d84e00",
+    "title": "자동제어 3. 라플라스 변환과 final value theorem",
+    "summary": "라플라스 변환과 최종값 정리를 시각 자료와 함께 정리한 노트입니다."
+  },
+  {
+    "slug": "자동제어 과제 1 Sol 16b44cd8bc53800991dbe55c61fe5fd3",
+    "title": "자동제어 과제 1. Sol",
+    "summary": "크루즈 컨트롤과 세그웨이 모델을 선형화하며 자동제어 과제 1의 풀이를 정리했습니다."
+  },
+  {
+    "slug": "자동제어 과제 2 Sol 18044cd8bc5380b5bcf9f0238fa0735c",
+    "title": "자동제어 과제 2. Sol",
+    "summary": "미분방정식에서 전달함수와 상태공간 표현을 유도하는 자동제어 과제 2 풀이입니다."
+  },
+  {
+    "slug": "2D Soft Landing Guidance 최종 풀이 cac0a769fc20484a9b04a597a4cfa72a",
+    "title": "2D Soft Landing Guidance 최종 풀이",
+    "summary": "2D 소프트 랜딩 가이던스 문제 풀이 초안으로 향후 세부 내용을 정리할 예정입니다."
+  },
+  {
+    "slug": "ase2010_hw7",
+    "title": "Flight data reconstruction",
+    "summary": "노이즈가 포함된 항공기 데이터를 활용해 추세 성분을 복원하는 최적화 기법을 실습했습니다."
+  },
+  {
+    "slug": "Formation_flight",
+    "title": "Formation Flight Own Solution",
+    "summary": "ASE6029 Formation Flight 과제를 자율적으로 풀이하고 ASE7030 응용 아이디어를 정리했습니다."
+  },
+  {
+    "slug": "ae-negative_K_gain",
+    "title": "Negative K gain 에서의 시스템 응답과 보드 선도",
+    "summary": "음의 게인에서의 제어 시스템 응답과 나이퀴스트/보드 선도 분석으로 안정 조건을 살폈습니다."
+  },
+  {
+    "slug": "ase2010_hw1",
+    "title": "ASE2010 Applied linear algebra: Homework #1",
+    "summary": "내적, 선형 변환, 최소 노름 해법을 포함한 선형대수 숙제 1 풀이를 정리했습니다."
+  },
+  {
+    "slug": "ase2010_final_exam_1",
+    "title": "인하대학교 항공우주공학과 선형대수학 2023 기말고사 1번 문제 풀이",
+    "summary": "인하대학교 선형대수 기말 1번 지하철 지연 문제를 행렬 모델링으로 풀이했습니다."
+  },
+  {
+    "slug": "ase2010_final_exam_2",
+    "title": "인하대학교 항공우주공학과 선형대수학 2023 기말고사 2번 문제 풀이",
+    "summary": "재사용 발사체의 소프트 랜딩을 최소 에너지 최적화 문제로 해결했습니다."
+  },
+  {
+    "slug": "cv-3",
+    "title": "Convex Optimization 3. Soft Landing guidance via Least squares",
+    "summary": "감쇠와 중력을 고려한 로켓 소프트 랜딩을 최소제곱 최적화로 모델링했습니다."
+  },
+  {
+    "slug": "Angle Constraints Path Optimization 10544cd8bc53805d897aed34663c63fd",
+    "title": "Angle Constraints Path Optimization",
+    "summary": "각도 제약을 갖는 경로 최적화 문제를 2차 계획법으로 정식화하고 풀이한 노트입니다."
   }
 ]


### PR DESCRIPTION
## Summary
- parse front-matter metadata from markdown posts and build a slug-aware lookup map
- display available metadata above study record pages while keeping markdown content clean
- add missing study record entries to the index and rename the linear algebra homework note for compatibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3b5a2cdd48332a972d6b4fc4d7e97